### PR TITLE
docs: フェーズ5 ルーティングの見直し - 評価と最小限の改善

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,11 +12,6 @@ Rails.application.routes.draw do
   post "/login", to: "sessions#create"
   delete "/logout", to: "sessions#destroy"
 
-  get 'password_resets/new'
-  get 'password_resets/edit'
-
-  get '/microposts', to: 'static_pages#home'
-
   resources :users do
     member do
       get :following, :followers

--- a/docs/ongoing/rules-compliance-migration/phase5-routing-evaluation.md
+++ b/docs/ongoing/rules-compliance-migration/phase5-routing-evaluation.md
@@ -1,0 +1,142 @@
+# フェーズ5: ルーティングの見直し - 評価結果
+
+## 現状のルーティング評価
+
+### 現在のルーティング構成
+
+#### RESTfulリソース（DHHルーティング準拠）
+- `users` - index, show, new, create, edit, update, destroy
+- `account_activations` - edit
+- `password_resets` - new, create, edit, update
+- `microposts` - create, destroy
+- `relationships` - create, destroy
+
+#### カスタムルート（DHHルーティング非準拠）
+
+1. **静的ページ**
+   - `GET /help` → `static_pages#help`
+   - `GET /about` → `static_pages#about`
+   - `GET /contact` → `static_pages#contact`
+   - `GET /microposts` → `static_pages#home` (ルートのエイリアス)
+
+2. **認証関連**
+   - `GET /signup` → `users#new`
+   - `GET /login` → `sessions#new`
+   - `POST /login` → `sessions#create`
+   - `DELETE /logout` → `sessions#destroy`
+
+3. **ユーザー関連（member routes）**
+   - `GET /users/:id/following` → `users#following`
+   - `GET /users/:id/followers` → `users#followers`
+
+---
+
+## DHHルーティングへの移行可能性の検討
+
+### 1. 静的ページ
+
+**現状**: `GET /help`, `/about`, `/contact`
+
+**DHHルーティングへの移行案**:
+- `resources :static_pages, only: [:show]` を使用し、`/static_pages/help` のような形式にする
+
+**評価**:
+- ❌ **推奨しない**: Webアプリケーションでは `/help` のようなシンプルなURLが一般的で、ユーザビリティが高い
+- SEO的にも `/help` の方が優れている
+- 静的ページはリソースとして扱う必要がない
+
+**結論**: 現状のまま維持
+
+---
+
+### 2. 認証関連
+
+**現状**: `/signup`, `/login`, `/logout`
+
+**DHHルーティングへの移行案**:
+- `resources :sessions, only: [:new, :create, :destroy]` を使用
+- `/signup` → `/users/new` に統一
+
+**評価**:
+- ⚠️ **部分的に検討可能**: 
+  - `/signup` → `/users/new` への統一は可能だが、`/signup` の方が直感的
+  - `/login` → `/sessions/new` への変更は可能だが、`/login` の方が一般的
+  - `/logout` → `DELETE /sessions/:id` への変更は可能だが、RESTfulな設計では `DELETE /sessions` が一般的
+
+**結論**: 現状のまま維持（Webアプリケーションでは `/login`, `/logout` が標準的）
+
+---
+
+### 3. ユーザー関連（member routes）
+
+**現状**: `/users/:id/following`, `/users/:id/followers`
+
+**DHHルーティングへの移行案**:
+- `following` と `followers` を別のリソースとして扱う
+- `resources :follows, only: [:index]` のような形式にする
+- または、`GET /users/:id` のクエリパラメータで制御（`?tab=following`）
+
+**評価**:
+- ✅ **移行可能**: 
+  - `GET /users/:id/follows?type=following` のような形式
+  - または `GET /users/:id/follows/following` のような形式
+  - ただし、現状の `/users/:id/following` の方が直感的で読みやすい
+
+**結論**: 現状のまま維持（member routesはRailsの標準的な機能で、DHHルーティングの一部として認められている）
+
+---
+
+## 総合評価
+
+### DHHルーティングへの完全移行
+
+**結論**: **推奨しない**
+
+**理由**:
+1. **Webアプリケーションの特性**: HTMLを返すWebアプリでは、ユーザーフレンドリーなURLが重要
+2. **Railsのベストプラクティス**: member routesはRailsの標準機能で、DHHルーティングの一部として認められている
+3. **既存の実装**: 現状のルーティングは動作しており、変更によるリスクを避けるべき
+4. **フェーズ1の方針**: 「ルールは変更せず、現状のカスタムルートを維持」という方針が既に決定済み
+
+### 改善可能な点
+
+1. **重複ルートの整理**:
+   - `GET /microposts` → `static_pages#home` は不要（`root` で十分）
+
+2. **ルートの整理**:
+   - `password_resets` の明示的なルート定義を削除（`resources` で十分）
+
+---
+
+## 推奨事項
+
+### 実施する改善
+
+1. **不要なルートの削除**:
+   ```ruby
+   # 削除: get '/microposts', to: 'static_pages#home'
+   # 削除: get 'password_resets/new'
+   # 削除: get 'password_resets/edit'
+   ```
+
+2. **ルートの整理**:
+   - `resources :password_resets` のみで十分（`only` オプションは既に指定済み）
+
+### 実施しない変更
+
+1. **静的ページのルート**: 現状のまま維持
+2. **認証関連のルート**: 現状のまま維持
+3. **ユーザーのmember routes**: 現状のまま維持
+
+---
+
+## 結論
+
+フェーズ5として、**最小限の改善のみ実施**し、DHHルーティングへの完全移行は行わない。
+
+**理由**:
+- 現状のルーティングはWebアプリケーションとして適切
+- member routesはRailsの標準機能で、DHHルーティングの一部
+- 変更によるリスクを避けるべき
+- フェーズ1の方針と整合性がある
+


### PR DESCRIPTION
## 概要

ルーティングの見直しを実施し、現状のルーティングを評価しました。DHHルーティングへの完全移行は推奨しないと判断し、不要なルートの削除のみ実施しました。

## 関連Issue

Issueなし

## 変更内容

- 現状のルーティングの評価を実施
- DHHルーティングへの移行可能性を検討
- 評価結果を`phase5-routing-evaluation.md`に記録
- 不要なルートを削除（重複定義の整理）
  - `get '/microposts'` を削除（`root`で十分）
  - `get 'password_resets/new'` を削除（`resources`で既に定義済み）
  - `get 'password_resets/edit'` を削除（`resources`で既に定義済み）

## 実装詳細

### 評価結果

1. **静的ページ**: 現状のまま維持（`/help`, `/about`, `/contact`はWebアプリとして適切）
2. **認証関連**: 現状のまま維持（`/login`, `/logout`は標準的）
3. **ユーザーのmember routes**: 現状のまま維持（`following`, `followers`はRailsの標準機能）

### 実施した改善

- 重複定義されていたルートを削除して、ルーティングを整理
- `resources`で既に定義されているルートの明示的な定義を削除

### 実施しなかった変更

- DHHルーティングへの完全移行は実施しない
  - 理由: Webアプリケーションとして現状のルーティングが適切、member routesはRailsの標準機能、変更によるリスクを避けるべき

## テスト

- [x] 既存のテストがすべて通過することを確認（112 tests, 544 assertions, 0 failures）
- [ ] 新規テストを追加（該当する場合）
- [ ] 手動テストを実施（該当する場合）

## チェックリスト

- [x] コードレビューを依頼する準備ができている
- [x] 関連するドキュメントを更新した（phase5-routing-evaluation.md）
- [x] 既存のテストがすべて通過する
- [x] 新しい警告やエラーがない

## スクリーンショット（該当する場合）

なし

## その他

フェーズ5として、rules-compliance-migrationタスクの一部として実施しました。

**結論**: 現状のルーティングはWebアプリケーションとして適切であり、DHHルーティングへの完全移行は推奨しない。静的ページ、認証関連、member routesは現状のまま維持する方針。
