### PR TITLE
feat: Vercelデプロイ用設定ファイルを追加 (#21)

### DIFF
--- a/api/index.rb
+++ b/api/index.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Vercel serverless function entry point for Rails application
+# This file is required for Vercel to handle Rails requests
+
+require_relative '../config/environment'
+
+# Rack application
+run Rails.application

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "version": 2,
+  "buildCommand": "bundle install && npm ci && bin/rails assets:precompile",
+  "devCommand": "bin/rails server",
+  "installCommand": "bundle install && npm ci",
+  "framework": null,
+  "outputDirectory": "public",
+  "routes": [
+    {
+      "src": "/assets/(.*)",
+      "dest": "/assets/$1"
+    },
+    {
+      "src": "/(.*)",
+      "dest": "/api/index.rb"
+    }
+  ],
+  "functions": {
+    "api/index.rb": {
+      "runtime": "ruby3.2",
+      "memory": 1024,
+      "maxDuration": 30
+    }
+  },
+  "env": {
+    "RAILS_ENV": "production",
+    "RAILS_LOG_TO_STDOUT": "true"
+  }
+}


### PR DESCRIPTION
## 概要

Vercelデプロイ用の設定ファイル（vercel.json）とAPIエントリーポイント（api/index.rb）を追加しました。

## 関連Issue

- Related to #21

## 変更内容

- `vercel.json`を作成（ビルドコマンド、ルーティング設定、環境変数設定）
- `api/index.rb`を作成（Vercel serverless function用エントリーポイント）

## 実装詳細

### vercel.json
- ビルドコマンド: `bundle install && npm ci && bin/rails assets:precompile`
- ルーティング設定: アセットとAPIリクエストのルーティング
- 関数設定: Ruby 3.2ランタイム、メモリ1024MB、最大実行時間30秒

### api/index.rb
- Vercelのserverless function用のエントリーポイント
- RailsアプリケーションをRackアプリケーションとして実行

## テスト

- [x] 既存のテストがすべて通過することを確認
- [ ] 新規テストを追加（該当する場合）
- [ ] 手動テストを実施（Vercelでのデプロイ確認は次のPRで実施）

## チェックリスト

- [x] コードレビューを依頼する準備ができている
- [x] 関連するドキュメントを更新した（該当する場合）
- [x] 既存のテストがすべて通過する
- [x] 新しい警告やエラーがない

## スクリーンショット（該当する場合）

該当なし

## その他

- Vercelでの実際のデプロイ確認は、環境変数の設定と合わせて次のPRで実施予定です
- RailsアプリケーションをVercelにデプロイする際は、追加の設定（データベース接続など）が必要になる可能性があります
