### PR TITLE
feat: mainブランチ保護とVercel自動デプロイのワークフローを追加 (#21)

### DIFF
--- a/.github/workflows/deploy-to-vercel.yml
+++ b/.github/workflows/deploy-to-vercel.yml
@@ -1,0 +1,22 @@
+name: Deploy to Vercel
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Deploy to Vercel
+        uses: amondnet/vercel-action@v25
+        with:
+          vercel-token: ${{ secrets.VERCEL_TOKEN }}
+          vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
+          vercel-args: '--prod'

--- a/.github/workflows/protect-main-branch.yml
+++ b/.github/workflows/protect-main-branch.yml
@@ -1,0 +1,24 @@
+name: Protect Main Branch
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches:
+      - main
+
+jobs:
+  prevent-direct-merge:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR is from develop branch
+        run: |
+          BASE_BRANCH="${{ github.event.pull_request.base.ref }}"
+          HEAD_BRANCH="${{ github.event.pull_request.head.ref }}"
+          
+          if [ "$BASE_BRANCH" == "main" ] && [ "$HEAD_BRANCH" != "develop" ]; then
+            echo "❌ Error: mainブランチへの直接マージは許可されていません。"
+            echo "developブランチ経由でマージしてください。"
+            exit 1
+          fi
+          
+          echo "✅ PR is from develop branch or base is not main"


### PR DESCRIPTION
## 概要

mainブランチへの直接マージを防ぐGitHub Actionsワークフローと、mainブランチへのマージ時にVercelへ自動デプロイするワークフローを追加しました。

## 関連Issue

- Related to #21

## 変更内容

- `.github/workflows/protect-main-branch.yml`を作成（mainブランチへの直接マージを防ぐ）
- `.github/workflows/deploy-to-vercel.yml`を作成（mainブランチへのマージ時にVercelへ自動デプロイ）

## 実装詳細

### protect-main-branch.yml
- mainブランチへのPRがdevelopブランチ以外から作成された場合にエラーを出力
- developブランチ経由でのマージを強制

### deploy-to-vercel.yml
- mainブランチへのpush時に自動的にVercelへデプロイ
- 手動実行も可能（workflow_dispatch）
- Vercelの認証情報はGitHub Secretsから取得

## テスト

- [x] 既存のテストがすべて通過することを確認
- [ ] 新規テストを追加（該当する場合）
- [ ] 手動テストを実施（ワークフローの動作確認は次回のmainマージ時に実施）

## チェックリスト

- [x] コードレビューを依頼する準備ができている
- [x] 関連するドキュメントを更新した（該当する場合）
- [x] 既存のテストがすべて通過する
- [x] 新しい警告やエラーがない

## スクリーンショット（該当する場合）

該当なし

## その他

- Vercelの認証情報（VERCEL_TOKEN, VERCEL_ORG_ID, VERCEL_PROJECT_ID）はGitHub Secretsに設定する必要があります
- ブランチ保護ルールはGitHubのリポジトリ設定でも設定することを推奨します
